### PR TITLE
Add logz.deinit() to README Usage

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,7 @@ try logz.setup(allocator, .{
     .output = .stdout,
     .encoding = .logfmt,
 });
+defer logz.deinit();
 
 // other places in your code
 logz.info().string("path", req.url.path).int("ms", elapsed).log();


### PR DESCRIPTION
Hey there! Thanks for an awesome library (and set of other libraries as well!)

I noticed that the first example in the readme may be made a bit better by including the `deinit` call to silence the GPA leak checker if it's in use.