### PR TITLE
Update dependencies to the new hash format

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -6,7 +6,7 @@
 	.dependencies = .{
 		.metrics = .{
 			.url = "https://github.com/karlseguin/metrics.zig/archive/cf2797bcb3aea7e5cdaf4de39c5550c70796e7b1.tar.gz",
-			.hash = "122061f30077ef518dd435d397598ab3c45daa3d2c25e6b45383fb94d0bd2c3af1af"
+			.hash = "N-V-__8AAHOzAQBh8wB371GN1DXTl1mKs8Rdqj0sJea0U4P7",
 		},
 	},
 }


### PR DESCRIPTION
Same as commit cb760af on http.zig (see karlseguin/http.zig@cb760af)

Incompatible hashes with the same build files make for especially weird build failures (see liskvork/liskvork#18)