### PR TITLE
fix: use io clock for timestamps

### DIFF
--- a/src/json.zig
+++ b/src/json.zig
@@ -12,7 +12,7 @@ const b64 = std.base64.url_safe_no_pad.Encoder;
 const META_LEN = "{\"@ts\":9999999999999,\"@l\":\"ERROR\",".len;
 
 const t = @import("t.zig");
-const timestamp = if (t.is_test) t.timestamp else std.time.milliTimestamp;
+const timestamp = @import("timestamp.zig").nowMilliseconds;
 
 pub const Json = struct {
     io: Io,
@@ -460,7 +460,7 @@ pub const Json = struct {
                 // whitespce in json is ignored, and putting it in keeps all our offsets the same
                 @memcpy(meta_buf[0..7], " \"@ts\":");
             }
-            _ = std.fmt.printInt(meta_buf[7..], timestamp(), 10, .lower, .{});
+            _ = std.fmt.printInt(meta_buf[7..], timestamp(self.io), 10, .lower, .{});
 
             switch (self.lvl) {
                 .Debug => {

--- a/src/logfmt.zig
+++ b/src/logfmt.zig
@@ -12,7 +12,7 @@ const b64 = std.base64.url_safe_no_pad.Encoder;
 const META_LEN = "@ts=9999999999999 @L=ERROR ".len;
 
 const t = @import("t.zig");
-const timestamp = if (t.is_test) t.timestamp else std.time.milliTimestamp;
+const timestamp = @import("timestamp.zig").nowMilliseconds;
 
 pub const LogFmt = struct {
     io: Io,
@@ -404,7 +404,7 @@ pub const LogFmt = struct {
             const meta_buf = meta[prefix_len..];
 
             @memcpy(meta_buf[0..4], "@ts=");
-            _ = std.fmt.printInt(meta_buf[4..], timestamp(), 10, .lower, .{});
+            _ = std.fmt.printInt(meta_buf[4..], timestamp(self.io), 10, .lower, .{});
 
             switch (self.lvl) {
                 .Debug => {

--- a/src/timestamp.zig
+++ b/src/timestamp.zig
@@ -1,0 +1,7 @@
+const std = @import("std");
+const t = @import("t.zig");
+
+pub fn nowMilliseconds(io: std.Io) i64 {
+    if (t.is_test) return t.timestamp();
+    return std.Io.Clock.real.now(io).toMilliseconds();
+}


### PR DESCRIPTION
Fixes #18.

Zig 0.16 removed `std.time.milliTimestamp`, which currently breaks non-test builds in `src/logfmt.zig` and `src/json.zig`.

`LogFmt` and `Json` already store `std.Io`, so this changes timestamp generation to use the existing I/O clock:

```zig
Io.Clock.real.now(io).toMilliseconds()
```

The test path still uses `t.timestamp()`.

Validation:

```text
zig build test
57 of 57 tests passed
```

I also verified this against a downstream Zig 0.16 consumer (`httpz-logger`) with:

```text
zig build test
zig build
```